### PR TITLE
Make WebP Work With XCode 11.2.2 Build

### DIFF
--- a/YYImage/YYImageCoder.m
+++ b/YYImage/YYImageCoder.m
@@ -24,13 +24,13 @@
 
 
 #ifndef YYIMAGE_WEBP_ENABLED
-#if __has_include(<webp/decode.h>) && __has_include(<webp/encode.h>) && \
-    __has_include(<webp/demux.h>)  && __has_include(<webp/mux.h>)
+#if __has_include(<WebP/decode.h>) && __has_include(<WebP/encode.h>) && \
+    __has_include(<WebP/demux.h>)  && __has_include(<WebP/mux.h>)
 #define YYIMAGE_WEBP_ENABLED 1
-#import <webp/decode.h>
-#import <webp/encode.h>
-#import <webp/demux.h>
-#import <webp/mux.h>
+#import <WebP/decode.h>
+#import <WebP/encode.h>
+#import <WebP/demux.h>
+#import <WebP/mux.h>
 #elif __has_include("webp/decode.h") && __has_include("webp/encode.h") && \
       __has_include("webp/demux.h")  && __has_include("webp/mux.h")
 #define YYIMAGE_WEBP_ENABLED 1


### PR DESCRIPTION
Xcode 11.2.2 break webp component by using wrong webp framework name 
Old webp ~> WebP