### PR TITLE
Feat: allow to force desired number of loops

### DIFF
--- a/YYImage/YYImage.h
+++ b/YYImage/YYImage.h
@@ -60,6 +60,14 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable YYImage *)imageWithData:(NSData *)data scale:(CGFloat)scale;
 
 /**
+ Force the number of loops the animation should perform, overriding intrinsic loop count
+ decoded from image.
+ 
+ @param animatedImageLoopCount Desired loop count.
+ */
+- (void)setAnimatedImageLoopCount:(NSUInteger)animatedImageLoopCount;
+
+/**
  If the image is created from data or file, then the value indicates the data type.
  */
 @property (nonatomic, readonly) YYImageType animatedImageType;

--- a/YYImage/YYImage.m
+++ b/YYImage/YYImage.m
@@ -89,6 +89,8 @@ static CGFloat _NSStringPathScale(NSString *string) {
     NSArray *_preloadedFrames;
     dispatch_semaphore_t _preloadedLock;
     NSUInteger _bytesPerFrame;
+    BOOL _isForcingLoopCount;
+    NSUInteger _forcedLoopCount;
 }
 
 + (YYImage *)imageNamed:(NSString *)name {
@@ -163,6 +165,8 @@ static CGFloat _NSStringPathScale(NSString *string) {
             _animatedImageMemorySize = _bytesPerFrame * decoder.frameCount;
         }
         self.yy_isDecodedForDisplay = YES;
+        _isForcingLoopCount = NO;
+        _forcedLoopCount = 0;
     }
     return self;
 }
@@ -192,6 +196,11 @@ static CGFloat _NSStringPathScale(NSString *string) {
             dispatch_semaphore_signal(_preloadedLock);
         }
     }
+}
+
+- (void)setAnimatedImageLoopCount:(NSUInteger)animatedImageLoopCount {
+    _isForcingLoopCount = YES;
+    _forcedLoopCount = animatedImageLoopCount;
 }
 
 #pragma mark - protocol NSCoding
@@ -227,7 +236,7 @@ static CGFloat _NSStringPathScale(NSString *string) {
 }
 
 - (NSUInteger)animatedImageLoopCount {
-    return _decoder.loopCount;
+    return _isForcingLoopCount ? _forcedLoopCount : _decoder.loopCount;
 }
 
 - (NSUInteger)animatedImageBytesPerFrame {


### PR DESCRIPTION
The rationale behind current PR is to allow YYImage clients to force desired number of loops on a single YYImage, so to override the loop count decoded from image.

It draws its implementation from [this comment](https://github.com/ibireme/YYImage/issues/1#issuecomment-165668942) found in an issue from original ibireme's repository.

At some point we thought to name the method as `forceAnimatedImageLoopCount`, but not sure if it aligns with general Obj-C and UIKit naming conventions. We also thought about providing some `clearAnimatedImageLoopCount` or `resetAnimatedImageLoopCount`, but maybe there's no use case for that at the moment.

What do you think?

Thanks to all maintainers